### PR TITLE
Change artifact names of services to avoid conflict with fuse-circuit…

### DIFF
--- a/greetings-service/pom.xml
+++ b/greetings-service/pom.xml
@@ -9,9 +9,9 @@
         <version>7.0.0.redhat-SNAPSHOT</version>
     </parent>
 
-    <artifactId>greetings-service</artifactId>
+    <artifactId>tracing-greetings-service</artifactId>
 
-    <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Greetings service</name>
+    <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Tracing Greetings service</name>
 
     <properties>
 

--- a/name-service/pom.xml
+++ b/name-service/pom.xml
@@ -9,9 +9,9 @@
         <version>7.0.0.redhat-SNAPSHOT</version>
     </parent>
 
-    <artifactId>name-service</artifactId>
+    <artifactId>tracing-name-service</artifactId>
 
-    <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Name service</name>
+    <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Tracing Name service</name>
 
     <properties>
 


### PR DESCRIPTION
The greeting-service and name-service artifact names here are not unique and conflict with the greeting-service and name-service artifact names in fuse-circuit-breaker-booster.     Adding a tracing prefix in order so that we can build in productization.