### PR TITLE
Change itest artifact name to avoid conflict with fuse-health-check-booster

### DIFF
--- a/itest/pom.xml
+++ b/itest/pom.xml
@@ -9,9 +9,10 @@
         <version>7.0.0.redhat-SNAPSHOT</version>
     </parent>
 
-    <artifactId>itest</artifactId>
+    <artifactId>tracing-itest</artifactId>
 
-    <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Integration Tests</name>
+    <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Tracing Integration Tests</name>
+
     <properties>
         <openshift.client.version>2.6.3</openshift.client.version>
     </properties>


### PR DESCRIPTION
Change itest artifact name to avoid conflict with fuse-health-check-booster