### PR TITLE
ENTESB-17165 Commit mcarletti patch to istio booster that fixes maven…

### DIFF
--- a/greetings-service/pom.xml
+++ b/greetings-service/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.redhat.fuse.boosters</groupId>
+        <groupId>com.redhat.fuse.boosters.tracing</groupId>
         <artifactId>fuse-istio-distributed-tracing-booster-parent</artifactId>
         <version>7.0.0.redhat-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tracing-greetings-service</artifactId>
+    <artifactId>greetings-service</artifactId>
 
     <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Tracing Greetings service</name>
 

--- a/greetings-service/src/main/jkube/deploymentconfig.yaml
+++ b/greetings-service/src/main/jkube/deploymentconfig.yaml
@@ -3,16 +3,16 @@ kind: DeploymentConfig
 metadata:
   labels:
     app: greetings-service
-    provider: fabric8
-    group: com.redhat.fuse.boosters
+    provider: jkube
+    group: com.redhat.fuse.boosters.tracing
   name: greetings-service
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   selector:
     app: greetings-service
-    provider: fabric8
-    group: com.redhat.fuse.boosters
+    provider: jkube
+    group: com.redhat.fuse.boosters.tracing
   strategy:
     rollingParams:
       timeoutSeconds: 3600
@@ -23,8 +23,8 @@ spec:
         sidecar.istio.io/inject: true
       labels:
         app: greetings-service
-        provider: fabric8
-        group: com.redhat.fuse.boosters
+        provider: jkube
+        group: com.redhat.fuse.boosters.tracing
     spec:
       volumes:
       - name: config-volume
@@ -32,17 +32,12 @@ spec:
           name: greetings-service
       containers:
       - name: greetings-service
+        env:
+          - name: NAME_SERVICE_SERVICE_HOST
+            value: "name-service"
+          - name: NAME_SERVICE_SERVICE_PORT
+            value: "8080"
         volumeMounts:
           - name: config-volume
             mountPath: /deployments/application.properties
             subPath: application.properties
-  triggers:
-  - type: ConfigChange
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - greetings-service
-      from:
-        kind: ImageStreamTag
-        name: greetings-service:latest
-    type: ImageChange

--- a/itest/pom.xml
+++ b/itest/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.redhat.fuse.boosters</groupId>
+        <groupId>com.redhat.fuse.boosters.tracing</groupId>
         <artifactId>fuse-istio-distributed-tracing-booster-parent</artifactId>
         <version>7.0.0.redhat-SNAPSHOT</version>
     </parent>

--- a/name-service/pom.xml
+++ b/name-service/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.redhat.fuse.boosters</groupId>
+        <groupId>com.redhat.fuse.boosters.tracing</groupId>
         <artifactId>fuse-istio-distributed-tracing-booster-parent</artifactId>
         <version>7.0.0.redhat-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tracing-name-service</artifactId>
+    <artifactId>name-service</artifactId>
 
     <name>Fuse :: Boosters :: Istio :: Distributed tracing :: Tracing Name service</name>
 

--- a/name-service/src/main/jkube/deploymentconfig.yaml
+++ b/name-service/src/main/jkube/deploymentconfig.yaml
@@ -3,16 +3,16 @@ kind: DeploymentConfig
 metadata:
   labels:
     app: name-service
-    provider: fabric8
-    group: com.redhat.fuse.boosters
+    provider: jkube
+    group: com.redhat.fuse.boosters.tracing
   name: name-service
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   selector:
     app: name-service
-    provider: fabric8
-    group: com.redhat.fuse.boosters
+    provider: jkube
+    group: com.redhat.fuse.boosters.tracing
   strategy:
     rollingParams:
       timeoutSeconds: 3600
@@ -23,8 +23,8 @@ spec:
         sidecar.istio.io/inject: true
       labels:
         app: name-service
-        provider: fabric8
-        group: com.redhat.fuse.boosters
+        provider: jkube
+        group: com.redhat.fuse.boosters.tracing
     spec:
       volumes:
       - name: config-volume
@@ -36,13 +36,3 @@ spec:
           - name: config-volume
             mountPath: /deployments/application.properties
             subPath: application.properties
-  triggers:
-  - type: ConfigChange
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - name-service
-      from:
-        kind: ImageStreamTag
-        name: name-service:latest
-    type: ImageChange

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.redhat.fuse.boosters</groupId>
+    <groupId>com.redhat.fuse.boosters.tracing</groupId>
     <artifactId>fuse-istio-distributed-tracing-booster-parent</artifactId>
     <version>7.0.0.redhat-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -14,8 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <fuse.bom.version>7.9.0.fuse-sb2-790065-redhat-00001</fuse.bom.version>
-        <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:1.9</docker.image.version>
+        <fuse.bom.version>7.10.0.fuse-sb2-7_10_0-00008-redhat-00001</fuse.bom.version>
+        <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:1.10</docker.image.version>
 
         <jaeger.version>0.31.0</jaeger.version>
     </properties>


### PR DESCRIPTION
ENTESB-17165 Commit mcarletti patch to istio booster that fixes maven artifact ids, jkube/fabric8 resources labels, added env variables, and removes the triggers