### PR TITLE
[ENTESB-22073] Update Boosters on launch.openshift.io to 7.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <fuse.bom.version>7.12.0.fuse-7_12_0-00016-redhat-00001</fuse.bom.version>
+        <fuse.bom.version>7.12.1.fuse-7_12_1-00009-redhat-00001</fuse.bom.version>
         <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:1.12</docker.image.version>
 
         <jaeger.version>0.31.0</jaeger.version>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-22073